### PR TITLE
regression: added property for call_verifier regression test

### DIFF
--- a/regression/call_verifier/README.md
+++ b/regression/call_verifier/README.md
@@ -9,7 +9,7 @@ function f(address a) public {
 ```
 The properties `call-failure` and `call-success` should both fail since we cannot know if the call will fail or not.
 
-The property `ex-call-is-made` check if an external call appened.
+The property `ex-call-is-made` checks if an external call appened.
 
 ## Properties
 - **call-failure**: the external call fails

--- a/regression/call_verifier/README.md
+++ b/regression/call_verifier/README.md
@@ -9,34 +9,37 @@ function f(address a) public {
 ```
 The properties `call-failure` and `call-success` should both fail since we cannot know if the call will fail or not.
 
+The property `ex-call-is-made` check if an external call appened.
+
 ## Properties
 - **call-failure**: the external call fails
 - **call-success**: the external call succeeds
+- **ex-call-is-made**: an external call has been performed
 
 ## Ground truth
-|        | call-failure | call-success |
-|--------|--------------|--------------|
-| **v1** | 0            | 0            |
+|        | call-failure    | call-success    | ex-call-is-made |
+|--------|-----------------|-----------------|-----------------|
+| **v1** | 0               | 0               | 1               |
  
 
 ## Experiments
 ### SolCMC
 #### Z3
-|        | call-failure | call-success |
-|--------|--------------|--------------|
-| **v1** | TN!          | TN!          |
+|        | call-failure    | call-success    | ex-call-is-made |
+|--------|-----------------|-----------------|-----------------|
+| **v1** | TN!             | TN!             | ND              |
  
 
 #### ELD
-|        | call-failure | call-success |
-|--------|--------------|--------------|
-| **v1** | TN!          | TN!          |
+|        | call-failure    | call-success    | ex-call-is-made |
+|--------|-----------------|-----------------|-----------------|
+| **v1** | TN!             | TN!             | ND              |
  
 
 
 ### Certora
-|        | call-failure | call-success |
-|--------|--------------|--------------|
-| **v1** | TN           | TN           |
+|        | call-failure    | call-success    | ex-call-is-made |
+|--------|-----------------|-----------------|-----------------|
+| **v1** | TN              | TN              | TP!             |
  
 

--- a/regression/call_verifier/certora/ex-call-is-made.spec
+++ b/regression/call_verifier/certora/ex-call-is-made.spec
@@ -1,0 +1,15 @@
+ghost bool external_call;
+
+hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    external_call = true;
+}
+
+rule ex_call_is_made {
+    require !external_call;
+
+    env e; 
+    address a;
+    f(e, a);
+
+    assert external_call;
+}

--- a/regression/call_verifier/ground-truth.csv
+++ b/regression/call_verifier/ground-truth.csv
@@ -1,3 +1,4 @@
 property,version,truth,footnote-md
 call-failure,v1,0,
 call-success,v1,0,
+ex-call-is-made,v1,1,

--- a/regression/call_verifier/skeleton.json
+++ b/regression/call_verifier/skeleton.json
@@ -3,6 +3,7 @@
     "specification": "file:specs.md",
     "properties": {
         "call-failure": "the external call fails",
-        "call-success": "the external call succeeds"
+        "call-success": "the external call succeeds",
+        "ex-call-is-made": "an external call has been performed"
     }
 }

--- a/regression/call_verifier/specs.md
+++ b/regression/call_verifier/specs.md
@@ -6,4 +6,4 @@ function f(address a) public {
 ```
 The properties `call-failure` and `call-success` should both fail since we cannot know if the call will fail or not.
 
-The property `ex-call-is-made` check if an external call appened.
+The property `ex-call-is-made` checks if an external call appened.

--- a/regression/call_verifier/specs.md
+++ b/regression/call_verifier/specs.md
@@ -5,3 +5,5 @@ function f(address a) public {
 }
 ```
 The properties `call-failure` and `call-success` should both fail since we cannot know if the call will fail or not.
+
+The property `ex-call-is-made` check if an external call appened.


### PR DESCRIPTION
The new property, `ex-call-is-made` check if an external call has been made.
We can checks this hooking the CALL opcode with certora